### PR TITLE
feat(socketlabs): add event proxy for socketlabs

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ async function main (data) {
     let results = await processEvents(data)
     return {
       statusCode: 200,
-      body: `Processed ${results.length} events`,
+      body: JSON.stringify(`Processed ${results.length} events`),
       isBase64Encoded: false
     }
   } catch(error) {

--- a/index.js
+++ b/index.js
@@ -8,10 +8,14 @@ const crypto = require('crypto')
 const Promise = require('bluebird')
 const sqs = require('sqs')
 
-const { AUTH, SQS_SUFFIX, EVENTS_SOURCE } = process.env
+const { AUTH, SQS_SUFFIX, PROVIDER } = process.env
 
-if (! AUTH || ! SQS_SUFFIX || ! EVENTS_SOURCE) {
+if (! AUTH || ! SQS_SUFFIX || ! PROVIDER) {
   throw new Error('Missing config')
+}
+
+if (PROVIDER !== 'sendgrid' && PROVIDER !== 'socketlabs') { 
+  throw new Error('Only the following providers are supported: sendgrid, socketlabs')
 }
 
 const AUTH_HASH = createHash(AUTH).split('')
@@ -83,7 +87,7 @@ async function processEvents (events) {
   )
 }
 
-const marshallEvent = require(`./${EVENTS_SOURCE}`)
+const marshallEvent = require(`./${PROVIDER}`)
 
 function sendEvent (event) {
   return SQS_CLIENT.pushAsync(QUEUES[event.notificationType], event)

--- a/index.js
+++ b/index.js
@@ -8,16 +8,9 @@ const crypto = require('crypto')
 const Promise = require('bluebird')
 const sqs = require('sqs')
 
-const EVENTS = {
-  BOUNCE: 'bounce',
-  DELIVERED: 'delivered',
-  DROPPED: 'dropped',
-  SPAM: 'spamreport'
-}
+const { AUTH, SQS_SUFFIX, EVENTS_SOURCE } = process.env
 
-const { AUTH, SQS_SUFFIX } = process.env
-
-if (! AUTH || ! SQS_SUFFIX) {
+if (! AUTH || ! SQS_SUFFIX || ! EVENTS_SOURCE) {
   throw new Error('Missing config')
 }
 
@@ -90,127 +83,7 @@ async function processEvents (events) {
   )
 }
 
-function marshallEvent (event) {
-  if (! event || ! event.timestamp || ! event.sg_message_id || ! event.event) {
-    return
-  }
-
-  const timestamp = mapTimestamp(event.timestamp)
-  const mail = marshallMailObject(event, timestamp)
-
-  switch (event.event) {
-    case EVENTS.BOUNCE:
-    case EVENTS.DROPPED:
-      return { mail, ...marshallBounceEvent(event, timestamp) }
-
-    case EVENTS.DELIVERED:
-      return { mail, ...marshallDeliveryEvent(event, timestamp) }
-
-    case EVENTS.SPAM:
-      return { mail, ...marshallComplaintEvent(event, timestamp) }
-  }
-}
-
-function mapTimestamp (timestamp) {
-  return new Date(timestamp * 1000).toISOString()
-}
-
-function marshallMailObject (event, timestamp) {
-  // Although I haven't seen it documented explicitly, sg_message_id appears to be
-  // the message id that Sendgrid returned from the call to `send`, appended with
-  // some stuff that begins with the string ".filter". This step just ensures we
-  // strip off the extra stuff.
-  //
-  // Example input: 14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0
-  // Example output: 14c5d75ce93.dfd.64b469
-  const messageId = event.sg_message_id.split('.filter')[0]
-
-  return {
-    timestamp,
-    messageId
-  }
-}
-
-function marshallBounceEvent (event, timestamp) {
-  let bounceType, bounceSubType
-
-  if (event.event === EVENTS.DROPPED) {
-    bounceType = 'Permanent'
-    bounceSubType = 'Suppressed'
-  } else {
-    // These status mappings aren't perfect but they're good enough. See
-    // the RFCs and the IANA registry for all the gory detail on statuses:
-    //
-    //   * https://tools.ietf.org/html/rfc5248
-    //   * https://tools.ietf.org/html/rfc3463
-    //   * https://www.iana.org/assignments/smtp-enhanced-status-codes/smtp-enhanced-status-codes.xhtml
-    const statusParts = event.status && event.status.split('.')
-    if (statusParts && statusParts.length === 3) {
-      if (statusParts[0] === '5') {
-        bounceType = 'Permanent'
-      }
-
-      bounceSubType = mapStatusToBounceSubType(statusParts)
-    }
-  }
-
-  return {
-    notificationType: 'Bounce',
-    bounce: {
-      bounceType: bounceType || 'Transient',
-      bounceSubType: bounceSubType || 'General',
-      bouncedRecipients: [
-        { emailAddress: event.email }
-      ],
-      timestamp,
-      feedbackId: event.sg_event_id
-    }
-  }
-}
-
-function mapStatusToBounceSubType (statusParts) {
-  switch (statusParts[1]) {
-    case '1':
-      return 'NoEmail'
-
-    case '2':
-      switch (statusParts[2]) {
-        case '2':
-          return 'MailboxFull'
-
-        case '3':
-          return 'MessageTooLarge'
-      }
-      break
-
-    case '6':
-      return 'ContentRejected'
-  }
-}
-
-function marshallDeliveryEvent (event, timestamp) {
-  return {
-    notificationType: 'Delivery',
-    delivery: {
-      timestamp,
-      recipients: [ event.email ],
-      smtpResponse: event.response
-    }
-  }
-}
-
-function marshallComplaintEvent (event, timestamp) {
-  return {
-    notificationType: 'Complaint',
-    complaint: {
-      complainedRecipients: [
-        { emailAddress: event.email }
-      ],
-      timestamp,
-      feedbackId: event.sg_event_id
-    }
-  }
-}
+const marshallEvent = require(`./${EVENTS_SOURCE}`)
 
 function sendEvent (event) {
   return SQS_CLIENT.pushAsync(QUEUES[event.notificationType], event)

--- a/index.js
+++ b/index.js
@@ -46,9 +46,15 @@ async function main (data) {
     if (data.body) {
       // Requests from the API gateway must be authenticated
       if (! data.queryStringParameters || ! authenticate(data.queryStringParameters.auth)) {
+        const errorResponse = { 
+          error: 'Unauthorized', 
+          errno: 999,
+          code: 401,
+          message: 'Request must provide a valid auth query param.'
+        }
         return {
           statusCode: 401,
-          body: 'Unauthorized',
+          body: JSON.stringify(errorResponse),
           isBase64Encoded: false
         }
       }
@@ -69,15 +75,24 @@ async function main (data) {
     }
 
     let results = await processEvents(data)
+    let response = { 
+      result: `Processed ${results.length} events` 
+    }
     return {
       statusCode: 200,
-      body: JSON.stringify(`Processed ${results.length} events`),
+      body: JSON.stringify(response),
       isBase64Encoded: false
     }
   } catch(error) {
+    const errorResponse = { 
+      error: 'Internal Server Error', 
+      errno: 999,
+      code: 500,
+      message: error && error.message ? error.message : 'Unspecified error'
+    }
     return {
       statusCode: 500,
-      body: 'Internal Server Error',
+      body: JSON.stringify(errorResponse),
       isBase64Encoded: false
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1464,9 +1464,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-      "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "readable-stream": {
       "version": "2.0.6",
@@ -1513,6 +1513,13 @@
         "stringstream": "~0.0.4",
         "tough-cookie": "~2.3.0",
         "tunnel-agent": "~0.4.1"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+          "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
+        }
       }
     },
     "require-uncached": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --ui tdd ./test.js"
+    "test": "mocha --ui tdd --recursive tests/"
   },
   "repository": {
     "type": "git",
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/mozilla/fxa-email-service#readme",
   "dependencies": {
     "bluebird": "^3.5.1",
+    "qs": "^6.5.2",
     "sqs": "^2.0.2"
   },
   "devDependencies": {

--- a/sendgrid.js
+++ b/sendgrid.js
@@ -1,0 +1,134 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+const EVENTS = {
+  BOUNCE: 'bounce',
+  DELIVERED: 'delivered',
+  DROPPED: 'dropped',
+  SPAM: 'spamreport'
+}
+
+function marshallEvent (event) {
+  if (! event || ! event.timestamp || ! event.sg_message_id || ! event.event) {
+    return
+  }
+
+  const timestamp = mapTimestamp(event.timestamp)
+  const mail = marshallMailObject(event, timestamp)
+
+  switch (event.event) {
+    case EVENTS.BOUNCE:
+    case EVENTS.DROPPED:
+      return { mail, ...marshallBounceEvent(event, timestamp) }
+
+    case EVENTS.DELIVERED:
+      return { mail, ...marshallDeliveryEvent(event, timestamp) }
+
+    case EVENTS.SPAM:
+      return { mail, ...marshallComplaintEvent(event, timestamp) }
+  }
+}
+
+function mapTimestamp (timestamp) {
+  return new Date(timestamp * 1000).toISOString()
+}
+
+function marshallMailObject (event, timestamp) {
+  // Although I haven't seen it documented explicitly, sg_message_id appears to be
+  // the message id that Sendgrid returned from the call to `send`, appended with
+  // some stuff that begins with the string ".filter". This step just ensures we
+  // strip off the extra stuff.
+  //
+  // Example input: 14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0
+  // Example output: 14c5d75ce93.dfd.64b469
+  const messageId = event.sg_message_id.split('.filter')[0]
+
+  return {
+    timestamp,
+    messageId
+  }
+}
+
+function marshallBounceEvent (event, timestamp) {
+  let bounceType, bounceSubType
+
+  if (event.event === EVENTS.DROPPED) {
+    bounceType = 'Permanent'
+    bounceSubType = 'Suppressed'
+  } else {
+    // These status mappings aren't perfect but they're good enough. See
+    // the RFCs and the IANA registry for all the gory detail on statuses:
+    //
+    //   * https://tools.ietf.org/html/rfc5248
+    //   * https://tools.ietf.org/html/rfc3463
+    //   * https://www.iana.org/assignments/smtp-enhanced-status-codes/smtp-enhanced-status-codes.xhtml
+    const statusParts = event.status && event.status.split('.')
+    if (statusParts && statusParts.length === 3) {
+      if (statusParts[0] === '5') {
+        bounceType = 'Permanent'
+      }
+
+      bounceSubType = mapStatusToBounceSubType(statusParts)
+    }
+  }
+
+  return {
+    notificationType: 'Bounce',
+    bounce: {
+      bounceType: bounceType || 'Transient',
+      bounceSubType: bounceSubType || 'General',
+      bouncedRecipients: [
+        { emailAddress: event.email }
+      ],
+      timestamp,
+      feedbackId: event.sg_event_id
+    }
+  }
+}
+
+function mapStatusToBounceSubType (statusParts) {
+  switch (statusParts[1]) {
+    case '1':
+      return 'NoEmail'
+
+    case '2':
+      switch (statusParts[2]) {
+        case '2':
+          return 'MailboxFull'
+
+        case '3':
+          return 'MessageTooLarge'
+      }
+      break
+
+    case '6':
+      return 'ContentRejected'
+  }
+}
+
+function marshallDeliveryEvent (event, timestamp) {
+  return {
+    notificationType: 'Delivery',
+    delivery: {
+      timestamp,
+      recipients: [ event.email ],
+      smtpResponse: event.response
+    }
+  }
+}
+
+function marshallComplaintEvent (event, timestamp) {
+  return {
+    notificationType: 'Complaint',
+    complaint: {
+      complainedRecipients: [
+        { emailAddress: event.email }
+      ],
+      timestamp,
+      feedbackId: event.sg_event_id
+    }
+  }
+}
+
+exports = module.exports = marshallEvent

--- a/sendgrid.js
+++ b/sendgrid.js
@@ -131,4 +131,6 @@ function marshallComplaintEvent (event, timestamp) {
   }
 }
 
-exports = module.exports = marshallEvent
+exports = module.exports = {
+  marshallEvent
+}

--- a/socketlabs.js
+++ b/socketlabs.js
@@ -6,7 +6,7 @@
 const { VALIDATION_KEY, SECRET_KEY } = process.env
 
 if (! VALIDATION_KEY || ! SECRET_KEY) {
-  throw new Error("Missing SocketLabs config")
+  throw new Error('Missing SocketLabs config')
 }
 
 const EVENTS = {
@@ -17,12 +17,12 @@ const EVENTS = {
 }
 
 function shouldValidate (event) {
-  if (event.Type !== "Validation") {
+  if (event.Type !== 'Validation') {
     return false
   }
 
   if (event.SecretKey !== SECRET_KEY) {
-    throw new Error("Invalid Secret Key")
+    throw new Error('Invalid Secret Key')
   }
 
   return true

--- a/socketlabs.js
+++ b/socketlabs.js
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+const EVENTS = {
+  VALIDATION: 'Validation',
+  COMPLAINT: 'Complaint',
+  FAILED: 'Failed',
+  DELIVERED: 'Delivered'
+}
+
+function marshallEvent (event) {
+  if (event.Type === EVENTS.VALIDATION) {
+    console.log('Still have to figure this one out.')
+    return
+  }
+
+  if (! event || ! event.Address || ! event.DateTime || ! event.Type) {
+    return
+  }
+
+  const timestamp = new Date(event.DateTime).toISOString()
+  const mail = marshallMailObject(event, timestamp)
+
+  switch (event.Type) {
+    case EVENTS.FAILED:
+      return { mail, ...marshallBounceEvent(event, timestamp) }
+
+    case EVENTS.DELIVERED:
+      return { mail, ...marshallDeliveryEvent(event, timestamp) }
+
+    case EVENTS.COMPLAINT:
+      return { mail, ...marshallComplaintEvent(event, timestamp) }
+  }
+}
+
+function marshallMailObject (event, timestamp) {
+  return {
+    timestamp,
+    messageId: event.MessageId
+  }
+}
+
+function marshallBounceEvent (event, timestamp) {
+  let [ bounceType, bounceSubType ] = mapFailureCodeToBounceTypes(event.FailureCode)
+
+  return {
+    notificationType: 'Bounce',
+    bounce: {
+      bounceType: bounceType,
+      bounceSubType: bounceSubType,
+      bouncedRecipients: [
+        { emailAddress: event.Address }
+      ],
+      timestamp,
+      feedbackId: event.MessageId
+    }
+  }
+}
+
+function mapFailureCodeToBounceTypes (failureCode) {
+  // SocketLabs failure codes: https://support.socketlabs.com/index.php/Knowledgebase/Article/View/123
+  // SNS bounce types: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html#bounce-types
+  switch (failureCode) {
+    case 1002:
+    case 1003:
+      return [ 'Permanent', 'Supressed' ]
+    case 1004:
+      return [ 'Transient', 'ContentRejected' ]
+    case 1007:
+      return [ 'Transient', 'AttachmentRejected' ]
+    case 2001:
+    case 2002:
+    case 2003:
+    case 2004:
+    case 2999:
+      return [ 'Permanent', 'NoEmail' ]
+    case 3001:
+      return [ 'Transitent', 'MailboxFull' ]
+    case 9999:
+      return [ 'Undetermined', 'Undetermined' ]
+    default:
+      return [ 'Transient', 'General' ]
+  }
+}
+
+function marshallDeliveryEvent (event, timestamp) {
+  return {
+    notificationType: 'Delivery',
+    delivery: {
+      timestamp,
+      recipients: [ event.Address ],
+      smtpResponse: event.Response
+    }
+  }
+}
+
+function marshallComplaintEvent (event, timestamp) {
+  return {
+    notificationType: 'Complaint',
+    complaint: {
+      complainedRecipients: [
+        { emailAddress: event.Address }
+      ],
+      timestamp,
+      feedbackId: event.MessageId
+    }
+  }
+}
+
+exports = module.exports = marshallEvent

--- a/tests/sendgrid.js
+++ b/tests/sendgrid.js
@@ -469,7 +469,7 @@ suite('sendgrid:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: '"Processed 9 events"',
+          body: '{"result":"Processed 9 events"}',
           isBase64Encoded: false
         }))
       })
@@ -485,7 +485,7 @@ suite('sendgrid:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 500,
-          body: 'Internal Server Error',
+          body: '{"error":"Internal Server Error","errno":999,"code":500,"message":"Unspecified error"}',
           isBase64Encoded: false
         }))
       })
@@ -566,7 +566,7 @@ suite('sendgrid:', () => {
     test('result is correct', () => {
       return promise.then(result => assert.deepEqual(result, {
         statusCode: 401,
-        body: 'Unauthorized',
+        body: '{"error":"Unauthorized","errno":999,"code":401,"message":"Request must provide a valid auth query param."}',
         isBase64Encoded: false
       }))
     })
@@ -600,7 +600,7 @@ suite('sendgrid:', () => {
     test('result is correct', () => {
       return promise.then(result => assert.deepEqual(result, {
         statusCode: 401,
-        body: 'Unauthorized',
+        body: '{"error":"Unauthorized","errno":999,"code":401,"message":"Request must provide a valid auth query param."}',
         isBase64Encoded: false
       }))
     })

--- a/tests/sendgrid.js
+++ b/tests/sendgrid.js
@@ -14,18 +14,19 @@ const { assert } = chai
 
 /* eslint-env mocha */
 
-suite('fxa-sendgrid-event-proxy:', () => {
+suite('sendgrid:', () => {
   let sqs, proxy
 
   setup(() => {
     process.env.AUTH = 'authentication string'
+    process.env.PROVIDER = 'sendgrid'
     process.env.SQS_SUFFIX = 'wibble'
     sqs = {
       push: sinon.spy()
     }
     sinon.spy(console, 'log')
     sinon.spy(console, 'error')
-    proxy = proxyquire('.', {
+    proxy = proxyquire('../', {
       sqs: () => sqs
     })
   })
@@ -468,7 +469,7 @@ suite('fxa-sendgrid-event-proxy:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: 'Processed 9 events',
+          body: '\"Processed 9 events\"',
           isBase64Encoded: false
         }))
       })

--- a/tests/sendgrid.js
+++ b/tests/sendgrid.js
@@ -469,7 +469,7 @@ suite('sendgrid:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: '\"Processed 9 events\"',
+          body: '"Processed 9 events"',
           isBase64Encoded: false
         }))
       })

--- a/tests/socketlabs.js
+++ b/tests/socketlabs.js
@@ -94,7 +94,7 @@ suite('socketlabs:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: '"Processed 1 events"',
+          body: '{"result":"Processed 1 events"}',
           isBase64Encoded: false
         }))
       })
@@ -159,7 +159,7 @@ suite('socketlabs:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: '"Processed 1 events"',
+          body: '{"result":"Processed 1 events"}',
           isBase64Encoded: false
         }))
       })
@@ -226,7 +226,7 @@ suite('socketlabs:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: '"Processed 1 events"',
+          body: '{"result":"Processed 1 events"}',
           isBase64Encoded: false
         }))
       })
@@ -305,7 +305,7 @@ suite('socketlabs:', () => {
     test('result is correct', () => {
       return promise.then(result => assert.deepEqual(result, {
         statusCode: 500,
-        body: 'Internal Server Error',
+        body: '{"error":"Internal Server Error","errno":999,"code":500,"message":"Invalid Secret Key"}',
         isBase64Encoded: false
       }))
     })
@@ -338,7 +338,7 @@ suite('socketlabs:', () => {
     test('result is correct', () => {
       return promise.then(result => assert.deepEqual(result, {
         statusCode: 200,
-        body: '"Processed 0 events"',
+        body: '{"result":"Processed 0 events"}',
         isBase64Encoded: false
       }))
     })
@@ -371,7 +371,7 @@ suite('socketlabs:', () => {
     test('result is correct', () => {
       return promise.then(result => assert.deepEqual(result, {
         statusCode: 200,
-        body: '"Processed 0 events"',
+        body: '{"result":"Processed 0 events"}',
         isBase64Encoded: false
       }))
     })

--- a/tests/socketlabs.js
+++ b/tests/socketlabs.js
@@ -94,7 +94,7 @@ suite('socketlabs:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: '\"Processed 1 events\"',
+          body: '"Processed 1 events"',
           isBase64Encoded: false
         }))
       })
@@ -159,7 +159,7 @@ suite('socketlabs:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: '\"Processed 1 events\"',
+          body: '"Processed 1 events"',
           isBase64Encoded: false
         }))
       })
@@ -208,7 +208,7 @@ suite('socketlabs:', () => {
         },
         complaint: {
           complainedRecipients: [
-            { emailAddress: "test@example.com" }
+            { emailAddress: 'test@example.com' }
           ],
           timestamp: '2012-10-01T14:07:26.000Z',
           feedbackId: '0000000155'
@@ -226,7 +226,7 @@ suite('socketlabs:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: '\"Processed 1 events\"',
+          body: '"Processed 1 events"',
           isBase64Encoded: false
         }))
       })
@@ -338,7 +338,7 @@ suite('socketlabs:', () => {
     test('result is correct', () => {
       return promise.then(result => assert.deepEqual(result, {
         statusCode: 200,
-        body: '\"Processed 0 events\"',
+        body: '"Processed 0 events"',
         isBase64Encoded: false
       }))
     })
@@ -371,7 +371,7 @@ suite('socketlabs:', () => {
     test('result is correct', () => {
       return promise.then(result => assert.deepEqual(result, {
         statusCode: 200,
-        body: '\"Processed 0 events\"',
+        body: '"Processed 0 events"',
         isBase64Encoded: false
       }))
     })

--- a/tests/socketlabs.js
+++ b/tests/socketlabs.js
@@ -1,0 +1,379 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+'use strict'
+
+const chai = require('chai')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+chai.use(require('chai-as-promised'))
+
+const { assert } = chai
+
+/* eslint-env mocha */
+
+suite('socketlabs:', () => {
+  let sqs, proxy
+
+  setup(() => {
+    process.env.AUTH = 'authentication string'
+    process.env.PROVIDER = 'socketlabs'
+    process.env.SQS_SUFFIX = 'wibble'
+    process.env.VALIDATION_KEY = 'validation'
+    process.env.SECRET_KEY = 'secret'
+    sqs = {
+      push: sinon.spy()
+    }
+    sinon.spy(console, 'log')
+    sinon.spy(console, 'error')
+    proxy = proxyquire('../', {
+      sqs: () => sqs
+    })
+  })
+
+  teardown(() => {
+    console.log.restore()
+    console.error.restore()
+  })
+
+  test('interface is correct', () => {
+    assert.isObject(proxy)
+    assert.isFunction(proxy.main)
+    assert.lengthOf(proxy.main, 1)
+  })
+
+  suite('call with a correct failure event:', () => {
+    let promise
+
+    setup((done) => {
+      promise = proxy.main({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: 'Type=Failed&DateTime=Mon%2C%2013%20Aug%202018%2020%3A29%3A59%20GMT&MailingId=&MessageId=bc449116-f031-4e23-98a4-2db3c34dc0cf&Address=foo%40example.com&SecretKey=secret&FailureCode=4003&Reason=500%205.4.0%20System%20rule%20action%20set%20to%20fail%20connection.&RemoteMta=&ServerId=19796&FailureType=0&FromAddress=verification%40latest.dev.lcip.org&BounceStatus=&DiagnosticCode=',
+        queryStringParameters: {
+          auth: 'authentication string'
+        }
+      })
+      setImmediate(done)
+    })
+
+    test('sqs.push was called once', () => {
+      assert.equal(sqs.push.callCount, 1)
+    })
+
+    test('sqs.push was called correctly', () => {
+      const args = sqs.push.args[0]
+      assert.deepEqual(args[1], {
+        notificationType: 'Bounce',
+        mail: {
+          timestamp: '2018-08-13T20:29:59.000Z',
+          messageId: 'bc449116-f031-4e23-98a4-2db3c34dc0cf'
+        },
+        bounce: {
+          bounceType: 'Transient',
+          bounceSubType: 'General',
+          bouncedRecipients: [
+            { emailAddress: 'foo@example.com' }
+          ],
+          timestamp: '2018-08-13T20:29:59.000Z',
+          feedbackId: 'bc449116-f031-4e23-98a4-2db3c34dc0cf'
+        }
+      })
+    })
+
+    suite('call all callbacks without errors:', () => {
+      setup(() => sqs.push.args.forEach(args => args[2]()))
+
+      test('promise is resolved', () => {
+        assert.isFulfilled(promise)
+      })
+
+      test('result is correct', () => {
+        return promise.then(result => assert.deepEqual(result, {
+          statusCode: 200,
+          body: '\"Processed 1 events\"',
+          isBase64Encoded: false
+        }))
+      })
+
+      test('console.log was called correctly', () => {
+        assert.equal(console.log.callCount, 1)
+        const args = console.log.args[0]
+        assert.lengthOf(args, 2)
+        assert.equal(args[0], 'Sent:')
+        assert.equal(args[1], 'Bounce')
+      })
+  
+      test('console.error was not called', () => {
+        assert.equal(console.error.callCount, 0)
+      })
+    })
+  })
+
+  suite('call with a correct delivery event:', () => {
+    let promise
+
+    setup((done) => {
+      promise = proxy.main({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: 'Type=Delivered&DateTime=Tue%2C%2014%20Aug%202018%2016%3A35%3A37%20GMT&MailingId=&MessageId=ca327159-f652-4193-ac67-d3cad0c0fafa&Address=real.email%40example.com&SecretKey=secret&RemoteMta=real-smtp-in.l.example.com&ServerId=99999&Response=250%202.0.0%20OK%201534264537%20z7-v6si7118563qta.91%20-%20gsmtp%0D%0A&LocalIp=10.24.177.135&FromAddress=verification%40latest.dev.lcip.org',
+        queryStringParameters: {
+          auth: 'authentication string'
+        }
+      })
+      setImmediate(done)
+    })
+
+    test('sqs.push was called once', () => {
+      assert.equal(sqs.push.callCount, 1)
+    })
+
+    test('sqs.push was called correctly', () => {
+      const args = sqs.push.args[0]
+      assert.deepEqual(args[1], {
+        notificationType: 'Delivery',
+        mail: {
+          timestamp: '2018-08-14T16:35:37.000Z',
+          messageId: 'ca327159-f652-4193-ac67-d3cad0c0fafa'
+        },
+        delivery: {
+          timestamp: '2018-08-14T16:35:37.000Z',
+          recipients: [ 'real.email@example.com' ],
+          smtpResponse: '250 2.0.0 OK 1534264537 z7-v6si7118563qta.91 - gsmtp\r\n'
+        }
+      })
+    })
+
+    suite('call all callbacks without errors:', () => {
+      setup(() => sqs.push.args.forEach(args => args[2]()))
+
+      test('promise is resolved', () => {
+        assert.isFulfilled(promise)
+      })
+
+      test('result is correct', () => {
+        return promise.then(result => assert.deepEqual(result, {
+          statusCode: 200,
+          body: '\"Processed 1 events\"',
+          isBase64Encoded: false
+        }))
+      })
+
+      test('console.log was called correctly', () => {
+        assert.equal(console.log.callCount, 1)
+        const args = console.log.args[0]
+        assert.lengthOf(args, 2)
+        assert.equal(args[0], 'Sent:')
+        assert.equal(args[1], 'Delivery')
+      })
+  
+      test('console.error was not called', () => {
+        assert.equal(console.error.callCount, 0)
+      })
+    })
+  })
+
+  suite('call with a correct complaint event:', () => {
+    let promise
+
+    setup((done) => {
+      promise = proxy.main({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: 'Type=Complaint&DateTime=Mon%2C%2001%20Oct%202012%2014%3A07%3A26%20GMT&MailingId=m012&MessageId=0000000155&Address=test%40example.com&ServerId=1000&SecretKey=secret&FblType=abuse&UserAgent=Yahoo%21-Mail-Feedback%2F1.0&From=test%40example.com&To=test%40example.com&Length=495',
+        queryStringParameters: {
+          auth: 'authentication string'
+        }
+      })
+      setImmediate(done)
+    })
+
+    test('sqs.push was called once', () => {
+      assert.equal(sqs.push.callCount, 1)
+    })
+
+    test('sqs.push was called correctly', () => {
+      const args = sqs.push.args[0]
+      assert.deepEqual(args[1], {
+        notificationType: 'Complaint',
+        mail: {
+          timestamp: '2012-10-01T14:07:26.000Z',
+          messageId: '0000000155'
+        },
+        complaint: {
+          complainedRecipients: [
+            { emailAddress: "test@example.com" }
+          ],
+          timestamp: '2012-10-01T14:07:26.000Z',
+          feedbackId: '0000000155'
+        }
+      })
+    })
+
+    suite('call all callbacks without errors:', () => {
+      setup(() => sqs.push.args.forEach(args => args[2]()))
+
+      test('promise is resolved', () => {
+        assert.isFulfilled(promise)
+      })
+
+      test('result is correct', () => {
+        return promise.then(result => assert.deepEqual(result, {
+          statusCode: 200,
+          body: '\"Processed 1 events\"',
+          isBase64Encoded: false
+        }))
+      })
+
+      test('console.log was called correctly', () => {
+        assert.equal(console.log.callCount, 1)
+        const args = console.log.args[0]
+        assert.lengthOf(args, 2)
+        assert.equal(args[0], 'Sent:')
+        assert.equal(args[1], 'Complaint')
+      })
+  
+      test('console.error was not called', () => {
+        assert.equal(console.error.callCount, 0)
+      })
+    })
+  })
+
+  suite('call with a correct validation event:', () => {
+    let promise
+
+    setup(() => {
+      promise = proxy.main({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: 'ServerId=99999&SecretKey=secret&Type=Validation',
+        queryStringParameters: {
+          auth: 'authentication string'
+        }
+      })
+      return promise
+    })
+
+    test('sqs.push was not called', () => {
+      assert.equal(sqs.push.callCount, 0)
+    })
+
+    test('promise is resolved', () => {
+      assert.isFulfilled(promise)
+    })
+
+    test('result is correct', () => {
+      return promise.then(result => assert.deepEqual(result, {
+        statusCode: 200,
+        body: 'validation',
+        isBase64Encoded: false
+      }))
+    })
+  })
+
+  suite('call with an incorrect validation event:', () => {
+    let promise
+
+    setup(() => {
+      promise = proxy.main({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: 'ServerId=99999&SecretKey=nope&Type=Validation',
+        queryStringParameters: {
+          auth: 'authentication string'
+        }
+      })
+      return promise
+    })
+
+    test('sqs.push was not called', () => {
+      assert.equal(sqs.push.callCount, 0)
+    })
+
+    test('promise is resolved', () => {
+      assert.isFulfilled(promise)
+    })
+
+    test('result is correct', () => {
+      return promise.then(result => assert.deepEqual(result, {
+        statusCode: 500,
+        body: 'Internal Server Error',
+        isBase64Encoded: false
+      }))
+    })
+  })
+
+  suite('call with a random event type:', () => {
+    let promise
+
+    setup(() => {
+      promise = proxy.main({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: 'ServerId=99999&SecretKey=secret&Type=Random',
+        queryStringParameters: {
+          auth: 'authentication string'
+        }
+      })
+      return promise
+    })
+
+    test('sqs.push was not called', () => {
+      assert.equal(sqs.push.callCount, 0)
+    })
+
+    test('promise is resolved', () => {
+      assert.isFulfilled(promise)
+    })
+
+    test('result is correct', () => {
+      return promise.then(result => assert.deepEqual(result, {
+        statusCode: 200,
+        body: '\"Processed 0 events\"',
+        isBase64Encoded: false
+      }))
+    })
+  })
+
+  suite('call with an incorrect body:', () => {
+    let promise
+
+    setup(() => {
+      promise = proxy.main({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: 'incorrect',
+        queryStringParameters: {
+          auth: 'authentication string'
+        }
+      })
+      return promise
+    })
+
+    test('sqs.push was not called', () => {
+      assert.equal(sqs.push.callCount, 0)
+    })
+
+    test('promise is resolved', () => {
+      assert.isFulfilled(promise)
+    })
+
+    test('result is correct', () => {
+      return promise.then(result => assert.deepEqual(result, {
+        statusCode: 200,
+        body: '\"Processed 0 events\"',
+        isBase64Encoded: false
+      }))
+    })
+  })
+})


### PR DESCRIPTION
Right now I only have the Sendgrid logic isolated and depending on an environment variable. I will add the SocketLabs logic now, but I wanted to check that this is a good way to do things.

**Update**

- I created the SocketLabs parser and added the validation stuff they require. I'm not really sure about code organization, but you can take a look and let me know, specially where I put the validation stuff inside `index.js`, that doesn't seem right. 
- I also created a lambda in AWS to test everything, that was alright and it works properly. Unfortunately SocketLabs is not able to validate using the validation key I provided. I tried returning it in the headers and in the body and none of those work, even though SocketLabs claims that we can return that key "anywhere in the response message" (https://support.socketlabs.com/index.php/Knowledgebase/Article/View/106). Probably I am misunderstanding something though, so let me know if you have any better ideas.
- I have been using some local unit tests for the parser stuff which I will organize into a commit and send soon.

**Update 2**

- SocketLabs sends the request in `x-www-form-urlencoded` format, that is why the validation was not working... Turns out the function was failing in `JSON.parse(body)` and returning an Internal Server Error to SocketLabs all this time. That was fixed.

r? @vladikoff @philbooth 