### PR TITLE
fix(package): "-y": store symbolic links as the link instead of the referenced file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --ui tdd --recursive tests/",
-    "build": "zip --recurse-paths fxa-email-event-proxy *.js *.json node_modules"
+    "build": "zip --recurse-paths -y fxa-email-event-proxy *.js *.json node_modules"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Minor nit. Usually only means files in ./node_modules/.bin, but seems more correct.

r? - @philbooth 