### PR TITLE
fix(socketlabs): add the ValidationKey to all responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,9 @@ async function main (data) {
     let response = { 
       result: `Processed ${results.length} events` 
     }
+    
+    response = provider.annotate(response)
+
     return {
       statusCode: 200,
       body: JSON.stringify(response),

--- a/sendgrid.js
+++ b/sendgrid.js
@@ -131,6 +131,12 @@ function marshallComplaintEvent (event, timestamp) {
   }
 }
 
+function annotate (response) {
+  // No-op
+  return response
+}
+
 exports = module.exports = {
+  annotate,
   marshallEvent
 }

--- a/socketlabs.js
+++ b/socketlabs.js
@@ -32,11 +32,23 @@ function shouldValidate (event) {
 }
 
 function validationResponse () {
-  return {
+  const response = {
     statusCode: 200,
-    body: VALIDATION_KEY,
+    body: JSON.stringify({ ValidationKey: VALIDATION_KEY }),
     isBase64Encoded: false
   }
+
+  return response
+}
+
+// Socketlabs API wants the response to always include the ValidationKey.
+// https://notify.docs.socketlabs.com/v1/example-post-events/failure-notification-example
+function annotate (response) {
+  if (! response.ValidationKey) {
+    response.ValidationKey = VALIDATION_KEY
+  }
+
+  return response
 }
 
 function marshallEvent (event) {
@@ -134,6 +146,7 @@ function marshallComplaintEvent (event, timestamp) {
 }
 
 exports = module.exports = {
+  annotate,
   shouldValidate,
   validationResponse,
   marshallEvent

--- a/tests/socketlabs.js
+++ b/tests/socketlabs.js
@@ -12,6 +12,8 @@ chai.use(require('chai-as-promised'))
 
 const { assert } = chai
 
+const TEST_VALIDATION_KEY = 'validation'
+
 /* eslint-env mocha */
 
 suite('socketlabs:', () => {
@@ -21,7 +23,7 @@ suite('socketlabs:', () => {
     process.env.AUTH = 'authentication string'
     process.env.PROVIDER = 'socketlabs'
     process.env.SQS_SUFFIX = 'wibble'
-    process.env.SOCKETLABS_VALIDATION_KEY = 'validation'
+    process.env.SOCKETLABS_VALIDATION_KEY = TEST_VALIDATION_KEY
     process.env.SOCKETLABS_SECRET_KEY = 'secret'
     sqs = {
       push: sinon.spy()
@@ -90,7 +92,7 @@ suite('socketlabs:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: '{"result":"Processed 1 events"}',
+          body: '{"result":"Processed 1 events","ValidationKey":"validation"}',
           isBase64Encoded: false
         }))
       })
@@ -159,7 +161,7 @@ suite('socketlabs:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: '{"result":"Processed 1 events"}',
+          body: '{"result":"Processed 1 events","ValidationKey":"validation"}',
           isBase64Encoded: false
         }))
       })
@@ -226,7 +228,7 @@ suite('socketlabs:', () => {
       test('result is correct', () => {
         return promise.then(result => assert.deepEqual(result, {
           statusCode: 200,
-          body: '{"result":"Processed 1 events"}',
+          body: '{"result":"Processed 1 events","ValidationKey":"validation"}',
           isBase64Encoded: false
         }))
       })
@@ -272,7 +274,7 @@ suite('socketlabs:', () => {
     test('result is correct', () => {
       return promise.then(result => assert.deepEqual(result, {
         statusCode: 200,
-        body: 'validation',
+        body: '{"ValidationKey":"validation"}',
         isBase64Encoded: false
       }))
     })
@@ -338,7 +340,7 @@ suite('socketlabs:', () => {
     test('result is correct', () => {
       return promise.then(result => assert.deepEqual(result, {
         statusCode: 200,
-        body: '{"result":"Processed 0 events"}',
+        body: '{"result":"Processed 0 events","ValidationKey":"validation"}',
         isBase64Encoded: false
       }))
     })
@@ -371,7 +373,7 @@ suite('socketlabs:', () => {
     test('result is correct', () => {
       return promise.then(result => assert.deepEqual(result, {
         statusCode: 200,
-        body: '{"result":"Processed 0 events"}',
+        body: '{"result":"Processed 0 events","ValidationKey":"validation"}',
         isBase64Encoded: false
       }))
     })


### PR DESCRIPTION
I was looking at the docs for the Socktlabs API and my reading of that is that the ValidationKey is supposed to be returned on each response. e.g., https://notify.docs.socketlabs.com/v1/example-post-events/failure-notification-example

So this PR adds an `annotate` method to each provider (no-op for SendGrid). If there's a better naming choice, or if I've read the docs wrong, let me know. (I'm not really sure if this is actually enforced by socketlabs, except on the validation, where they will take it anywhere in the response body. ¯\_(ツ)_/¯)

